### PR TITLE
Handle X-MJ-Vars as json string

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,18 @@ It is possible to set specific Mailjet headers or custom user-defined headers, t
 For example:
 
 ```php
-$message->getHeaders()->addTextHeader('X-MJ-TemplateLanguage', true);
+$headers = $message->getHeaders();
+
+$headers->addTextHeader('X-MJ-TemplateID', $templateId);
+$headers->addTextHeader('X-MJ-TemplateLanguage', true);
+$vars = array("myFirstVar" => "foo", "mySecondVar" => "bar");
+$headers->addTextHeader('X-MJ-Vars', json_encode($vars));
 ```
 
-[Mailjet Email Headers documentation v3](https://dev.mailjet.com/guides/#send-api-json-properties)
-[Mailjet Email Headers documentation v3.1](https://dev.mailjet.com/guides/#adding-email-headers)
+Note: You need to `json_encode`your array of variables in order to be compatible with SMTP transport. 
+
+* [Mailjet Email Headers documentation v3](https://dev.mailjet.com/guides/#send-api-json-properties)
+* [Mailjet Email Headers documentation v3.1](https://dev.mailjet.com/guides/#adding-email-headers)
 
 ## Mailjet bulk sending
 

--- a/SwiftMailer/MessageFormat/BaseMessagePayload.php
+++ b/SwiftMailer/MessageFormat/BaseMessagePayload.php
@@ -71,7 +71,11 @@ abstract class BaseMessagePayload implements MessageFormatStrategyInterface
             /** @var \Swift_Mime_Headers_UnstructuredHeader $value */
             if (null !== $value = $messageHeaders->get($headerName)) {
                 // Handle custom headers
-                $mailjetData[$mailjetHeaders[$headerName]] = $value->getValue();
+                if($headerName == "X-MJ-Vars" && is_string($value->getValue())){
+                    $mailjetData[$mailjetHeaders[$headerName]] = json_decode($value->getValue());
+                } else {
+                    $mailjetData[$mailjetHeaders[$headerName]] = $value->getValue();
+                }
                 // remove Mailjet specific headers
                 $messageHeaders->removeAll($headerName);
             }


### PR DESCRIPTION
See issue #5 

In order to remove SwiftMailer error/warning when you try to pass an array of variables to X-MJ-Vars, I propose to json_encode when we set the header and in our BaseMessagePayload we json_decode in order to create the payload for the API properly.

Only tested against API v3.1 on my side.

 Code Example:

```php
    /**
     * Configure specific headers for message
     * @method configureHeaders
     * @param  \Swift_Message    $message
     * @return \Swift_Message
     */
    protected function configureHeaders(\Swift_Message $message, $templateId, array $vars)
    {
        //Configure Headers
        $headers = $message->getHeaders();

        $headers->addTextHeader('X-MJ-TemplateID', $templateId);
        $headers->addTextHeader('X-MJ-TemplateLanguage', true);
        $headers->addTextHeader('X-MJ-Vars', json_encode($vars));

        return $message;
    }
```
