### PR TITLE
updated swiftmailer version to 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.4",
         "mailjet/mailjet-apiv3-php": "^1.2",
-        "swiftmailer/swiftmailer": "~5.4"
+        "swiftmailer/swiftmailer": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
updated swiftmailer version, as some projects (i.e.: sylius) can also require swiftmailer in a recent version.