### PR TITLE
#26 Does not initialize the name property if not provided

### DIFF
--- a/SwiftMailer/MessageFormat/MessagePayloadV31.php
+++ b/SwiftMailer/MessageFormat/MessagePayloadV31.php
@@ -182,10 +182,19 @@ class MessagePayloadV31 extends BaseMessagePayload {
      * @return array|null
      */
     private function getReplyTo(Swift_Mime_Message $message) {
-        if (is_array($message->getReplyTo())) {
-            return array('Email' => key($message->getReplyTo()), 'Name' => current($message->getReplyTo()));
-        } elseif (is_string($message->getReplyTo())) {
-            return array('Email' => $message->getReplyTo());
+        $replyTo = $message->getReplyTo();
+
+        if (is_array($replyTo)) {
+            $email = key($replyTo);
+            $name = current($replyTo);
+
+            if (empty($name)){
+                return array('Email' => $email);
+            }
+
+            return array('Email' => $email, 'Name' => $name);
+        } elseif (is_string($replyTo)) {
+            return array('Email' => $replyTo);
         } else {
             return null;
         }

--- a/Tests/SwiftMailer/MailjetTransportv31Test.php
+++ b/Tests/SwiftMailer/MailjetTransportv31Test.php
@@ -255,6 +255,32 @@ class MailjetTransportv31Test extends TestCase {
         }
     }
 
+    public function testReplyToWithoutName(){
+        $message = new \Swift_Message('Test Subject', '<p>Foo bar</p>', 'text/html');
+        $message->setReplyTo('alice+replyTo@nowhere.com');
+        $message->setFrom('alice+from@nowhere.com');
+        $message->setTo('bob@nowhere.com');
+        $message->setBody("Hello world!", 'text/plain');
+
+        $transport = $this->createTransport();
+        $mailjetMessage = $transport->messageFormat->getMailjetMessage($message)['Messages'][0];
+
+        $this->assertEquals(["Email" => 'alice+replyTo@nowhere.com'], $mailjetMessage['ReplyTo']);
+    }
+
+    public function testReplyTo(){
+        $message = new \Swift_Message('Test Subject', '<p>Foo bar</p>', 'text/html');
+        $message->setReplyTo('alice+replyTo@nowhere.com', 'Alice');
+        $message->setFrom('alice+from@nowhere.com');
+        $message->setTo('bob@nowhere.com');
+        $message->setBody("Hello world!", 'text/plain');
+
+        $transport = $this->createTransport();
+        $mailjetMessage = $transport->messageFormat->getMailjetMessage($message)['Messages'][0];
+
+        $this->assertEquals(["Email" => 'alice+replyTo@nowhere.com', "Name" => "Alice"], $mailjetMessage['ReplyTo']);
+    }
+
     /**
      * @param string $email
      * @param string $name


### PR DESCRIPTION
Allows to set a replyTo address without a name, using the API v3.1.